### PR TITLE
feat: 회원 조회 기능 추가

### DIFF
--- a/src/main/java/com/tanppoppo/testore/testore/exam/repository/ExamPaperRepository.java
+++ b/src/main/java/com/tanppoppo/testore/testore/exam/repository/ExamPaperRepository.java
@@ -35,4 +35,7 @@ public interface ExamPaperRepository extends JpaRepository<ExamPaperEntity, Inte
     @Query("SELECT COUNT(le) > 0 FROM ItemLikeEntity le WHERE le.memberId.memberId = :memberId AND le.itemId = :examPaperId")
     Boolean getLikeState(@Param("memberId") Integer memberId, @Param("examPaperId") Integer examPaperId);
 
+    @Query("SELECT COUNT(ep) FROM ExamPaperEntity ep WHERE ep.ownerId = :memberId")
+    Integer countExamPapersByOwnerId(@Param("memberId") Integer memberId);
+
 }

--- a/src/main/java/com/tanppoppo/testore/testore/exam/service/ExamService.java
+++ b/src/main/java/com/tanppoppo/testore/testore/exam/service/ExamService.java
@@ -14,4 +14,5 @@ public interface ExamService {
 
     Map<String, Object> selectPaperDetail(int examPaperId);
 
+    Integer countExamPapersByOwnerId(Integer memberId);
 }

--- a/src/main/java/com/tanppoppo/testore/testore/exam/service/ExamServiceImpl.java
+++ b/src/main/java/com/tanppoppo/testore/testore/exam/service/ExamServiceImpl.java
@@ -121,4 +121,16 @@ public class ExamServiceImpl implements ExamService {
 
     }
 
+    /**
+     *  특정 사용자가 소유한 시험지의 총 개수를 반환함.
+     *
+     * @author dhkdtjs1541
+     * @param memberId 시험지를 소유한 사용자의 ID
+     * @return 사용자가 소유한 시험지의 개수
+     */
+    @Override
+    public Integer countExamPapersByOwnerId(Integer memberId) {
+        return epr.countExamPapersByOwnerId(memberId);
+    }
+
 }

--- a/src/main/java/com/tanppoppo/testore/testore/member/controller/MemberController.java
+++ b/src/main/java/com/tanppoppo/testore/testore/member/controller/MemberController.java
@@ -1,10 +1,14 @@
 package com.tanppoppo.testore.testore.member.controller;
 
+import com.tanppoppo.testore.testore.exam.service.ExamService;
 import com.tanppoppo.testore.testore.member.dto.MemberDTO;
 import com.tanppoppo.testore.testore.member.entity.MemberEntity;
 import com.tanppoppo.testore.testore.member.service.MemberService;
+import com.tanppoppo.testore.testore.security.AuthenticatedUser;
+import com.tanppoppo.testore.testore.word.service.WordService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,6 +33,8 @@ import java.lang.reflect.Member;
 public class MemberController {
 
     private final MemberService ms;
+    private final ExamService es;
+    private final WordService ws;
 
     /**
      * 계정 페이지 이동
@@ -36,9 +42,16 @@ public class MemberController {
      * @return 계정 페이지를 반환합니다.
      */
     @GetMapping("info")
-    public String info(Model model) {
-//        MemberEntity loggedInMember = ms.getLoggedInMember();
-//        model.addAttribute("email", loggedInMember.getEmail());
+    public String info(Model model, @AuthenticationPrincipal AuthenticatedUser user) {
+        Integer examPaperCount = es.countExamPapersByOwnerId(user.getId());
+        Integer wordBookCount = ws.countWordBooksByOwnerId(user.getId());
+        Integer pointCount = ms.getPointSumByMemberId(user.getId());
+
+        model.addAttribute("email", user.getEmail());
+        model.addAttribute("nickname", user.getNickname());
+        model.addAttribute("examPaperCount", examPaperCount);
+        model.addAttribute("wordBookCount", wordBookCount);
+        model.addAttribute("pointCount", pointCount);
 
         return "member/info-main";
     }

--- a/src/main/java/com/tanppoppo/testore/testore/member/repository/PointRepository.java
+++ b/src/main/java/com/tanppoppo/testore/testore/member/repository/PointRepository.java
@@ -1,7 +1,11 @@
 package com.tanppoppo.testore.testore.member.repository;
 
+import com.tanppoppo.testore.testore.member.entity.MemberEntity;
 import com.tanppoppo.testore.testore.member.entity.PointEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 /**
  * {@link PointEntity}를 위한 데이터 접근을 관리하는 리포지토리 인터페이스
@@ -9,5 +13,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @version 0.1.0
  * @since 0.1.0
  */
+@Repository
 public interface PointRepository extends JpaRepository<PointEntity, Integer>  {
+
+    List<PointEntity> findByMemberId(MemberEntity memberId);
+
 }

--- a/src/main/java/com/tanppoppo/testore/testore/member/service/MemberService.java
+++ b/src/main/java/com/tanppoppo/testore/testore/member/service/MemberService.java
@@ -11,5 +11,6 @@ public interface MemberService {
     MemberEntity findByEmailVerificationToken(String token);
     String generateEmailVerificationToken(MemberEntity member);
     void sendEmailVerification(String email, String newToken);
+    int getPointSumByMemberId(int memberId);
 
 }

--- a/src/main/java/com/tanppoppo/testore/testore/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/tanppoppo/testore/testore/member/service/MemberServiceImpl.java
@@ -2,7 +2,9 @@ package com.tanppoppo.testore.testore.member.service;
 
 import com.tanppoppo.testore.testore.member.dto.MemberDTO;
 import com.tanppoppo.testore.testore.member.entity.MemberEntity;
+import com.tanppoppo.testore.testore.member.entity.PointEntity;
 import com.tanppoppo.testore.testore.member.repository.MemberRepository;
+import com.tanppoppo.testore.testore.member.repository.PointRepository;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -24,6 +27,7 @@ public class MemberServiceImpl implements MemberService {
     private final MemberRepository mr;
     private final BCryptPasswordEncoder PasswordEncoder;
     private final JavaMailSender mailSender;
+    private final PointRepository pr;
 
     @Override
     public void joinMember(MemberDTO memberDTO) {
@@ -153,6 +157,22 @@ public class MemberServiceImpl implements MemberService {
         String newToken = generateEmailVerificationToken(member);
         sendEmailVerification(member.getEmail(), newToken);
 
+    }
+
+    /**
+     * 회원의 포인트 합계를 계산하는 메서드
+     *
+     * @author dhkdtjs1541
+     * @param memberId 회원의 ID
+     * @return 회원의 포인트 합계
+     * @throws RuntimeException 회원을 찾을 수 없을 경우 발생
+     */
+    @Override
+    public int getPointSumByMemberId(int memberId) {
+        MemberEntity member = mr.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+        List<PointEntity> points = pr.findByMemberId(member);
+        return points.stream().mapToInt(PointEntity::getPointChange).sum(); // 포인트의 합계 계산
     }
 
     /**

--- a/src/main/java/com/tanppoppo/testore/testore/word/repository/WordBookRespository.java
+++ b/src/main/java/com/tanppoppo/testore/testore/word/repository/WordBookRespository.java
@@ -1,9 +1,0 @@
-package com.tanppoppo.testore.testore.word.repository;
-
-import com.tanppoppo.testore.testore.word.entity.WordBookEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface WordBookRespository extends JpaRepository<WordBookEntity, Integer> {
-}

--- a/src/main/java/com/tanppoppo/testore/testore/word/service/WordService.java
+++ b/src/main/java/com/tanppoppo/testore/testore/word/service/WordService.java
@@ -1,4 +1,7 @@
 package com.tanppoppo.testore.testore.word.service;
 
 public interface WordService {
+
+    Integer countWordBooksByOwnerId(Integer ownerId);
+
 }

--- a/src/main/java/com/tanppoppo/testore/testore/word/service/WordServiceImpl.java
+++ b/src/main/java/com/tanppoppo/testore/testore/word/service/WordServiceImpl.java
@@ -1,4 +1,24 @@
 package com.tanppoppo.testore.testore.word.service;
 
-public class WordServiceImpl {
+import com.tanppoppo.testore.testore.word.repository.WordBookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WordServiceImpl implements WordService {
+
+    private final WordBookRepository wbr;
+
+    /**
+     * 특정 사용자가 소유한 단어장의 개수를 반환
+     *
+     * @author dhkdtjs1541
+     * @param ownerId 단어장 소유자의 ID
+     * @return 소유한 단어장의 개수
+     */
+    @Override
+    public Integer countWordBooksByOwnerId(Integer ownerId) {
+        return wbr.countByOwnerId(ownerId);
+    }
 }

--- a/src/main/resources/templates/member/info-main.html
+++ b/src/main/resources/templates/member/info-main.html
@@ -9,10 +9,10 @@
 <div class="flex items-center min-h-[calc(6rem+4vw)] px-10">
 
   <div class="flex flex-col justify-center gap-2 w-full px-4 font-bold">
-    <div class="text-[calc(0.7rem+0.4vw)] text-gray-700">rudgns1243@naver.com</div>
-    <div class="text-[calc(0.6rem+0.5vw)] text-gray-400 font-medium break-all">gyahury</div>
+    <div class="text-[calc(0.7rem+0.4vw)] text-gray-700" th:text="${email}"></div>
+    <div class="text-[calc(0.6rem+0.5vw)] text-gray-400 font-medium break-all" th:text="${nickname}"></div>
     <div class="text-[calc(0.5rem+0.4vw)] text-gray-400">
-      단어장 : <span>2</span> | 시험지 : <span>2</span> | 포인트 : <span>234</span>p</div>
+      단어장 : <span th:text="${wordBookCount}"></span> | 시험지 : <span th:text="${examPaperCount}"></span> | 포인트 : <span th:text="${pointCount}"></span>p</div>
   </div>
   <svg class="w-[calc(2rem+1vw)] h-[calc(2rem+1vw)] text-gray-400" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24"
        height="24" fill="none" viewBox="0 0 24 24">


### PR DESCRIPTION
- 사용자가 소유한 시험지의 개수를 반환하는 기능 추가 및 구현
- 이메일, 닉네임, 시험지, 단어장, 포인트 정보를 동적으로 표시하도록 수정
- WordBookRepository 이름 수정 및 사용자가 소유한 단어장 목록과 개수를 조회하는 기능 추가
- 단어장 관련 메서드 구현
- PointRepository 추가